### PR TITLE
Use Pattern, instead of preg_quote()

### DIFF
--- a/core/tests/Drupal/KernelTests/AssertContentTrait.php
+++ b/core/tests/Drupal/KernelTests/AssertContentTrait.php
@@ -8,6 +8,7 @@ use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Render\RenderContext;
 use Symfony\Component\CssSelector\CssSelectorConverter;
+use TRegx\CleanRegex\Pattern;
 
 /**
  * Provides test methods to assert content.
@@ -189,12 +190,8 @@ trait AssertContentTrait {
         $value = count($parts) > 1 ? 'concat(' . implode(', \'"\', ', $parts) . ')' : $parts[0];
       }
 
-      // Use preg_replace_callback() instead of preg_replace() to prevent the
-      // regular expression engine from trying to substitute backreferences.
-      $replacement = function ($matches) use ($value) {
-        return $value;
-      };
-      $xpath = preg_replace_callback('/' . preg_quote($placeholder) . '\b/', $replacement, $xpath);
+      $pattern = Pattern::inject('@\b', [$placeholder]);
+      $xpath = $pattern->replace($xpath)->with($value);
     }
     return $xpath;
   }

--- a/core/tests/Drupal/Tests/WebAssert.php
+++ b/core/tests/Drupal/Tests/WebAssert.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\LogicalNot;
+use TRegx\CleanRegex\Pattern;
 
 /**
  * Defines a class with methods for asserting presence of elements during tests.
@@ -469,12 +470,8 @@ class WebAssert extends MinkWebAssert {
         $value = count($parts) > 1 ? 'concat(' . implode(', \'"\', ', $parts) . ')' : $parts[0];
       }
 
-      // Use preg_replace_callback() instead of preg_replace() to prevent the
-      // regular expression engine from trying to substitute backreferences.
-      $replacement = function ($matches) use ($value) {
-        return $value;
-      };
-      $xpath = preg_replace_callback('/' . preg_quote($placeholder) . '\b/', $replacement, $xpath);
+      $pattern = Pattern::inject('@\b', $placeholder);
+      $xpath = $pattern->replace($xpath)->with($value);
     }
     return $xpath;
   }


### PR DESCRIPTION
I noticed you're using a lot of regular expression from PHP in your application. Perhaps you'd be interested in dedicated library for regular expressions?

Among other things, it has methods `with()` and `withReferences()`, the later replacing references, but `with()` replaces values literally, so you wouldn't have to worry about it. Also, `preg_quote()` has some flaws, using prepared patterns has many advantages.

I don't know exactly how you manage dependencies, but to install it you only need to do
```
composer require rawr/t-regx
```